### PR TITLE
More robust regex to match ruby version

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -56,7 +56,7 @@ pub fn github(req: &mut Request) -> IronResult<Response> {
 }
 
 fn parse_gemfile(gemfile: String) -> String {
-    let re = Regex::new("ruby [\"\'](.*?)[\"\']").unwrap();
+    let re = Regex::new("^\\s*ruby\\s*[\"'](.*?)[\"']").unwrap();
     let mut s;
     match re.captures(&gemfile) {
         Some(caps) => s = caps.get(1).map_or("", |m| m.as_str()),


### PR DESCRIPTION
Prevents false-positive matches like:

```
# ruby '2.4.1' (commented out code!)
```

Allows matches like:

```
ruby '2.3.4'
  ruby "2.4.0" # (extra space)
ruby   '2.4.1' # (extra space)
ruby"2.2.9" # (no space)
```

Still not a perfect solution, since you could have e.g.

```
=begin
ruby '2.4.1'
=end
```
... Ideally, this should use a parser. But it should work fine for 99.9% of Gemfiles.